### PR TITLE
Completa pedidos no status On Hold

### DIFF
--- a/includes/class-wc-pagseguro-gateway.php
+++ b/includes/class-wc-pagseguro-gateway.php
@@ -687,7 +687,7 @@ class WC_PagSeguro_Gateway extends WC_Payment_Gateway {
 						break;
 					case 4:
 						// if the payment is pending and the transaction status goes directly to status 4, we must complete the payment
-						if ( method_exists( $order, 'get_status' ) && 'pending' === $order->get_status() ) {
+						if ( method_exists( $order, 'get_status' ) && in_array( $order->get_status(), array('on-hold', 'pending' ) ) ) {
 							$order->payment_complete( sanitize_text_field( (string) $posted->code ) );
 						}
 


### PR DESCRIPTION
Caso um pedido que esteja no status On Hold não receba a notificação informando o status Paga e receba o status Disponível, o módulo computa o recebimento do pagamento e dá andamento ao pedido por meio da função payment_complete.